### PR TITLE
support for streaming to unix socket

### DIFF
--- a/libstream/Makefile.am
+++ b/libstream/Makefile.am
@@ -3,6 +3,7 @@ LIBSTREAM = 	libstream/compress.c \
 		libstream/stream.c \
 		libstream/stream.h \
 		libstream/url_file.c \
+		libstream/url_unix.c \
 		libstream/url_tcp.c \
 		libstream/url_telnet.c \
 		libstream/url_termcast.c \

--- a/libstream/stream.c
+++ b/libstream/stream.c
@@ -152,6 +152,8 @@ export int open_stream(int fd, const char* url, int mode, const char **error)
             fd=dup(wr? 1 : 0);
         else if (match_prefix(url, "file://"))
             fd=open_file(url+7, mode, error);
+        else if (match_prefix(url, "unix://"))
+            fd=open_unix(url+7, mode, error);
         else if (match_prefix(url, "tcp://"))
             fd=open_tcp(url+6, mode, error);
         else if (match_prefix(url, "telnet://"))

--- a/libstream/stream.h
+++ b/libstream/stream.h
@@ -1,5 +1,6 @@
 int open_file(const char* url, int mode, const char **error);
 int open_tcp(const char* url, int mode, const char **error);
+int open_unix(const char* socket, int mode, const char **error);
 int open_telnet(const char* url, int mode, const char **error);
 int open_termcast(const char* url, int mode, const char **error);
 int match_suffix(const char *txt, const char *ext, int skip);
@@ -7,6 +8,7 @@ int match_prefix(const char *txt, const char *ext);
 int filter(void func(int,int,const char*), int fd, int wr, const char *arg, const char **error);
 
 int connect_tcp(const char *url, int port, const char **rest, const char **error);
+int connect_unix(const char *socket_path, const char **error);
 void telnet(int sock, int fd, const char *arg);
 #ifdef IS_WIN32
 void reap_streams(void);

--- a/libstream/url_unix.c
+++ b/libstream/url_unix.c
@@ -1,0 +1,60 @@
+#include "config.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/types.h>
+#ifdef HAVE_NETDB_H
+# include <netdb.h>
+#endif
+#ifdef HAVE_SYS_SOCKET_H
+# include <sys/socket.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+# include <netinet/in.h>
+#endif
+#include <string.h>
+#include <errno.h>
+#include "export.h"
+#include "stream.h"
+#include "compat.h"
+#include "gettext.h"
+VISIBILITY_ENABLE
+#include "ttyrec.h"
+VISIBILITY_DISABLE
+
+#include <sys/socket.h>
+#include <sys/un.h>
+
+int connect_unix(const char *socket_path, const char **error)
+{
+    struct sockaddr_un addr;
+    int fd;
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, socket_path, sizeof(addr.sun_path)-1);
+    fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (connect(fd, (struct sockaddr*)&addr, sizeof(addr)) == -1)
+    {
+        fd = -1;
+        *error=strerror(errno);
+    }
+    return fd;
+}
+
+
+int open_unix(const char* socket_path, int mode, const char **error)
+{
+    int fd;
+
+    if ((fd=connect_unix(socket_path, error))==-1)
+        return -1;
+
+    // no bidi streams
+    if (mode&SM_WRITE)
+        shutdown(fd, SHUT_RD);
+    else
+        shutdown(fd, SHUT_WR);
+
+    return fd;
+}


### PR DESCRIPTION
Extends streaming support to handle unix sockets

./termrec unix:///tmp/logserver.sock

In this case (unlike TCP) "logserver" may easily get know user id and process id of running termrec.