### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper-compat (= 12), libbz2-dev, zlib1g-dev,
   liblzma-dev, libzstd-dev, libcurl4-gnutls-dev
 Standards-Version: 4.5.0
 Rules-Requires-Root: no
-Homepage: http://angband.pl/termrec.html
+Homepage: https://angband.pl/termrec.html
 Vcs-Git: https://github.com/kilobyte/termrec.git -b debian
 Vcs-Browser: https://github.com/kilobyte/termrec/tree/debian
 

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,6 @@ Vcs-Git: https://github.com/kilobyte/termrec.git -b debian
 Vcs-Browser: https://github.com/kilobyte/termrec/tree/debian
 
 Package: termrec
-Section: misc
 Architecture: any
 Multi-Arch: foreign
 Depends: libtty1 (>= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Section: misc
 Maintainer: Adam Borowski <kilobyte@angband.pl>
 Build-Depends: debhelper-compat (= 12), libbz2-dev, zlib1g-dev,
   liblzma-dev, libzstd-dev, libcurl4-gnutls-dev
-Standards-Version: 4.5.0
+Standards-Version: 4.5.1
 Rules-Requires-Root: no
 Homepage: https://angband.pl/termrec.html
 Vcs-Git: https://github.com/kilobyte/termrec.git -b debian

--- a/debian/rules
+++ b/debian/rules
@@ -1,7 +1,6 @@
 #!/usr/bin/make -f
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 export DEB_CFLAGS_MAINT_APPEND  = -Wall
-export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 
 %:
 	dh $@

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,5 @@
+---
+Bug-Database: https://github.com/kilobyte/termrec/issues
+Bug-Submit: https://github.com/kilobyte/termrec/issues/new
+Repository: https://github.com/kilobyte/termrec.git
+Repository-Browse: https://github.com/kilobyte/termrec


### PR DESCRIPTION
Fix some issues reported by lintian

* Use secure URI in Homepage field. ([homepage-field-uses-insecure-uri](https://lintian.debian.org/tags/homepage-field-uses-insecure-uri))

* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository))

* Update standards version to 4.5.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))

* Remove Section on termrec that duplicates source. ([binary-control-field-duplicates-source](https://lintian.debian.org/tags/binary-control-field-duplicates-source))

* Avoid explicitly specifying -Wl,--as-needed linker flag. ([debian-rules-uses-as-needed-linker-flag](https://lintian.debian.org/tags/debian-rules-uses-as-needed-linker-flag))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/termrec/57865262-1090-4358-acef-0a3d4a57d1db.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/3d/c1565dff31474ad85717bb1981369eb41f5e8e.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/3f/1c83c326fe71aa532709059143a3ce2be4dea0.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/a8/5413b027ee3162dc78c5d7d448574f6450e1db.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/b7/f0e98308cfaf15a237f9a36fd91be2dffe306b.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/38/192d2bb74acfbd6ca001d9f311ba615b6b50e2.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/45/e9844aa82a9baf04574a3288b75129d404920d.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/a8/8504b4f1c3590efd053297a2a015da38feb78c.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/c2/8b5f470dfaf1c31a749b26a2038fefe9039981.debug
### Control files of package libtty-dev: lines which differ (wdiff format)
* Homepage: [-http&#8203;://angband.pl/termrec.html-] {+https&#8203;://angband.pl/termrec.html+}
### Control files of package libtty1: lines which differ (wdiff format)
* Depends: libbz2-1.0, libc6 (>= 2.14), libcurl3-gnutls (>= 7.16.2), liblzma5 (>= 5.1.1alpha+20120614), libzstd1 (>= [-1.3.2),-] {+1.4.0),+} zlib1g (>= 1:1.1.4)
* Homepage: [-http&#8203;://angband.pl/termrec.html-] {+https&#8203;://angband.pl/termrec.html+}

No differences were encountered between the control files of package \*\*libtty1-dbgsym\*\*
### Control files of package termrec: lines which differ (wdiff format)
* Homepage: [-http&#8203;://angband.pl/termrec.html-] {+https&#8203;://angband.pl/termrec.html+}
### Control files of package termrec-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-38192d2bb74acfbd6ca001d9f311ba615b6b50e2 45e9844aa82a9baf04574a3288b75129d404920d a88504b4f1c3590efd053297a2a015da38feb78c c28b5f470dfaf1c31a749b26a2038fefe9039981-] {+3dc1565dff31474ad85717bb1981369eb41f5e8e 3f1c83c326fe71aa532709059143a3ce2be4dea0 a85413b027ee3162dc78c5d7d448574f6450e1db b7f0e98308cfaf15a237f9a36fd91be2dffe306b+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/57865262-1090-4358-acef-0a3d4a57d1db/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/57865262-1090-4358-acef-0a3d4a57d1db/diffoscope)).
